### PR TITLE
Always Read Response Bodies

### DIFF
--- a/embeddings.go
+++ b/embeddings.go
@@ -341,11 +341,12 @@ func (s *embStore) computePostEmbedding(ctx context.Context, host string, r *Rep
 		return nil, fmt.Errorf("embedding server errored: %w", err)
 	}
 
+	ob, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	if resp.StatusCode != 200 {
-		ob, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
 		fmt.Println("error on posts: ", string(ob))
 		return nil, fmt.Errorf("bad response status from embedding server: %d", resp.StatusCode)
 	}
@@ -623,8 +624,8 @@ func (s *embStore) sendEmbeddingBatch(ctx context.Context, be embedBackendConfig
 	}
 	defer resp.Body.Close()
 
+	bb, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		bb, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("non-200 status code from post embedding updates: %d - %s", resp.StatusCode, string(bb))
 	}
 
@@ -690,8 +691,8 @@ func (s *embStore) sendUserEmbeddings(ctx context.Context, be embedBackendConfig
 	}
 	defer resp.Body.Close()
 
+	bb, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		bb, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("non-200 status code from embedding updates: %d - %s", resp.StatusCode, string(bb))
 	}
 
@@ -843,8 +844,8 @@ func (s *embStore) sendClusterUpdates(ctx context.Context, be embedBackendConfig
 		}
 		defer resp.Body.Close()
 
+		bb, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode != 200 {
-			bb, _ := io.ReadAll(resp.Body)
 			return fmt.Errorf("non-200 status code from cluster update: %d - %s", resp.StatusCode, string(bb))
 		}
 
@@ -1047,11 +1048,12 @@ func (s *embStore) computeUserEmbedding(ctx context.Context, embhost, repo strin
 		return nil, err
 	}
 
+	ob, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	if resp.StatusCode != 200 {
-		ob, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
 		fmt.Println("error on user: ", string(ob))
 		return nil, fmt.Errorf("bad response status from embedding server: %d", resp.StatusCode)
 	}
@@ -1100,8 +1102,8 @@ func (s *embStore) processDeadLetterQueue(ctx context.Context, be embedBackendCo
 		return nil, err
 	}
 
+	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		b, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("got non-200 status from backend for dead letter queue (%d): %s", resp.StatusCode, string(b))
 	}
 

--- a/main.go
+++ b/main.go
@@ -2450,6 +2450,11 @@ func (s *Server) maybeFetchImage(ctx context.Context, uri string, dir string) er
 			return fmt.Errorf("fetch error: %w", err)
 		}
 
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
 		if resp.StatusCode != 200 {
 			lastError = fmt.Errorf("non-200 response code: %d", resp.StatusCode)
 			if resp.StatusCode == 404 {
@@ -2458,11 +2463,6 @@ func (s *Server) maybeFetchImage(ctx context.Context, uri string, dir string) er
 			slog.Warn("image fetch failed", "attempt", i, "error", lastError, "uri", uri)
 			time.Sleep(time.Second * time.Duration(i+1))
 			continue
-		}
-
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
 		}
 
 		if err := s.putImageToCache(cidpart, data); err != nil {


### PR DESCRIPTION
This is something I think we should carry over from last week. We were seeing lots of HTTP timeouts, particularly with requests that had to go over a long distance.

Per the [stdlib](https://pkg.go.dev/net/http#Response):

> The default HTTP client's Transport may not reuse HTTP/1.x "keep-alive" TCP connections if the Body is not read to completion and closed.

Because we weren't reading http responses to the end, we were seeing a large amount of connection churn, particularly on [this request](https://github.com/whyrusleeping/market/blob/1600d9a4d5a5877e9090ef7088e0a9eab7fd00a4/embeddings.go#L679). We shipped this and the issue was resolved.